### PR TITLE
EJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "js-yaml": "2.x.x",
     "marked-engine": "0.1.x",
     "highlight.js": "7.x.x",
-    "debug": "0.7.x"
+    "debug": "0.7.x",
+    "ejs": "0.8.x"
   },
   "devDependencies": {
     "mocha": "1.x.x",


### PR DESCRIPTION
I tried the example in the README, but kept getting an error saying that it couldn't find the EJS module. I've updated package.json to include EJS. However, I also realize you may have left it out on purpose so that people can specify which engine they want with the 'layout engine' setting.

Also, are there any plans to use the script in 'bin' to generate a Kerouac skeleton site?
